### PR TITLE
Remove CUDA device hardcoding and add command line argument

### DIFF
--- a/src/quick_local.py
+++ b/src/quick_local.py
@@ -1,5 +1,5 @@
 import os
-os.environ["CUDA_VISIBLE_DEVICES"] = "5"  
+# os.environ["CUDA_VISIBLE_DEVICES"] = "5"  # Moved to command line argument
 import asyncio
 import torch
 
@@ -183,4 +183,18 @@ async def main():
 
 
 if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="LightRAG Quick Local Example")
+    parser.add_argument(
+        "--cuda_device",
+        type=str,
+        default=None,
+        help="CUDA device to use (e.g., '0' or '0,1'). If not specified, uses system default."
+    )
+    args = parser.parse_args()
+    
+    # Set CUDA device if specified
+    if args.cuda_device is not None:
+        os.environ["CUDA_VISIBLE_DEVICES"] = args.cuda_device
+    
     asyncio.run(main())

--- a/src/run.py
+++ b/src/run.py
@@ -1,5 +1,5 @@
 import os
-os.environ["CUDA_VISIBLE_DEVICES"] = "5"  
+# os.environ["CUDA_VISIBLE_DEVICES"] = "5"  # Moved to command line argument
 import asyncio
 import torch
 import argparse # 1. argparse 모듈 임포트
@@ -208,7 +208,17 @@ if __name__ == "__main__":
         default=0.7, # 기본값 0.7
         help="Weight for BERTScore (default: 0.7)"
     )
+    parser.add_argument(
+        "--cuda_device",
+        type=str,
+        default=None,
+        help="CUDA device to use (e.g., '0' or '0,1'). If not specified, uses system default."
+    )
     args = parser.parse_args()
+    
+    # Set CUDA device if specified
+    if args.cuda_device is not None:
+        os.environ["CUDA_VISIBLE_DEVICES"] = args.cuda_device
     
     # 5. 파싱된 가중치로 Reranker 인스턴스 생성
     reranker = CustomReranker(


### PR DESCRIPTION
Fixes #2 입니다. CUDA_VISIBLE_DEVICES가 하드코딩되어 있어서 다른 GPU 환경에서 실행이 안되는 문제를 수정했습니다. run.py와 quick_local.py 둘다 수정했어요. 이제 --cuda_device 옵션으로 원하는 GPU를 지정할 수 있습니다. 지정하지 않으면 시스템 기본값을 사용합니다.